### PR TITLE
WIP: Add fullscreen toggle to display settings.

### DIFF
--- a/Resources/Text.json
+++ b/Resources/Text.json
@@ -153,6 +153,7 @@
 	"menu_option_sound_musicVol": "Music volume",
 	"menu_option_display_scale": "Window scale",
 	"menu_option_display_ratio": "Aspect ratio",
+	"menu_option_is_fullscreen": "Fullscreen",
 	"menu_option_display_minimap": "Minimap display",
 	"menu_option_display_bottomKeys": "Show weapon icons",
 	"menu_option_display_keymap": "Show input display",

--- a/Scenes/UI/MenuLayers/DisplayOptions.tscn
+++ b/Scenes/UI/MenuLayers/DisplayOptions.tscn
@@ -196,7 +196,7 @@ hide_frame = true
 [connection signal="button_toggled" from="MainVBox/ScrollContainer/VBoxContainer/BottomKeys" to="MainVBox" method="on_bottom_keys_toggled"]
 [connection signal="button_toggled" from="MainVBox/ScrollContainer/VBoxContainer/InputMap" to="MainVBox" method="on_input_map_toggled"]
 [connection signal="button_toggled" from="MainVBox/ScrollContainer/VBoxContainer/InGameTime" to="MainVBox" method="on_igt_toggled"]
-[connection signal="button_toggled" from="MainVBox/ScrollContainer/VBoxContainer/Framerate" to="MainVBox" method="on_fullscreen_toggled"]
+[connection signal="button_toggled" from="MainVBox/ScrollContainer/VBoxContainer/Framerate" to="MainVBox" method="on_fps_toggled"]
 [connection signal="option_cycled" from="MainVBox/ScrollContainer/VBoxContainer/Particles" to="MainVBox" method="on_particles_cycled"]
 [connection signal="option_cycled" from="MainVBox/ScrollContainer/VBoxContainer/Darkness" to="MainVBox" method="on_darkness_cycled"]
 [connection signal="button_toggled" from="MainVBox/ScrollContainer/VBoxContainer/PaletteShader" to="MainVBox" method="on_pshader_toggled"]

--- a/Scenes/UI/MenuLayers/DisplayOptions.tscn
+++ b/Scenes/UI/MenuLayers/DisplayOptions.tscn
@@ -59,17 +59,27 @@ layout_mode = 2
 focus_neighbor_left = NodePath(".")
 focus_neighbor_top = NodePath("../Scale")
 focus_neighbor_right = NodePath(".")
-focus_neighbor_bottom = NodePath("../Minimap")
+focus_neighbor_bottom = NodePath("../Fullscreen")
 focus_next = NodePath("../Minimap")
 focus_previous = NodePath("../Scale")
 header_id = "menu_option_display_ratio"
 auto_select_mode = true
 cycle_options = Array[String](["5:3", "5:4", "4:3", "16:9", "16:10"])
 
-[node name="Minimap" parent="MainVBox/ScrollContainer/VBoxContainer" instance=ExtResource("2_msw3w")]
+[node name="Fullscreen" parent="MainVBox/ScrollContainer/VBoxContainer" instance=ExtResource("4_jxl7l")]
 layout_mode = 2
 focus_neighbor_left = NodePath(".")
 focus_neighbor_top = NodePath("../Ratio")
+focus_neighbor_right = NodePath(".")
+focus_neighbor_bottom = NodePath("../Minimap")
+focus_next = NodePath("../Framerate")
+focus_previous = NodePath("../InputMap")
+text_id = "menu_option_is_fullscreen"
+
+[node name="Minimap" parent="MainVBox/ScrollContainer/VBoxContainer" instance=ExtResource("2_msw3w")]
+layout_mode = 2
+focus_neighbor_left = NodePath(".")
+focus_neighbor_top = NodePath("../Fullscreen")
 focus_neighbor_right = NodePath(".")
 focus_neighbor_bottom = NodePath("../BottomKeys")
 focus_next = NodePath("../BottomKeys")
@@ -181,11 +191,12 @@ hide_frame = true
 
 [connection signal="option_cycled" from="MainVBox/ScrollContainer/VBoxContainer/Scale" to="MainVBox" method="on_scale_cycled"]
 [connection signal="option_cycled" from="MainVBox/ScrollContainer/VBoxContainer/Ratio" to="MainVBox" method="on_ratio_cycled"]
+[connection signal="button_toggled" from="MainVBox/ScrollContainer/VBoxContainer/Fullscreen" to="MainVBox" method="on_fullscreen_toggled"]
 [connection signal="option_cycled" from="MainVBox/ScrollContainer/VBoxContainer/Minimap" to="MainVBox" method="on_minimap_cycled"]
 [connection signal="button_toggled" from="MainVBox/ScrollContainer/VBoxContainer/BottomKeys" to="MainVBox" method="on_bottom_keys_toggled"]
 [connection signal="button_toggled" from="MainVBox/ScrollContainer/VBoxContainer/InputMap" to="MainVBox" method="on_input_map_toggled"]
 [connection signal="button_toggled" from="MainVBox/ScrollContainer/VBoxContainer/InGameTime" to="MainVBox" method="on_igt_toggled"]
-[connection signal="button_toggled" from="MainVBox/ScrollContainer/VBoxContainer/Framerate" to="MainVBox" method="on_fps_toggled"]
+[connection signal="button_toggled" from="MainVBox/ScrollContainer/VBoxContainer/Framerate" to="MainVBox" method="on_fullscreen_toggled"]
 [connection signal="option_cycled" from="MainVBox/ScrollContainer/VBoxContainer/Particles" to="MainVBox" method="on_particles_cycled"]
 [connection signal="option_cycled" from="MainVBox/ScrollContainer/VBoxContainer/Darkness" to="MainVBox" method="on_darkness_cycled"]
 [connection signal="button_toggled" from="MainVBox/ScrollContainer/VBoxContainer/PaletteShader" to="MainVBox" method="on_pshader_toggled"]

--- a/Scripts/UI/MenuLayers/DisplayOptions.gd
+++ b/Scripts/UI/MenuLayers/DisplayOptions.gd
@@ -44,6 +44,21 @@ func on_input_map_toggled(value) -> void:
 func on_igt_toggled(value) -> void:
 	ProjectSettings.set_setting("game/ui/in_game_time", value)
 
+func on_fullscreen_toggled(value) -> void:
+	var window = get_window()
+	
+	if value:
+		window.mode = Window.MODE_FULLSCREEN
+	else:
+		window.mode = Window.MODE_WINDOWED
+		
+		# Restore window size
+		var ratio_idx = ProjectSettings.get("display/window/size/aspect_ratio")
+		var ratio = Statics.ASPECT_RATIOS[ratio_idx]
+		
+		var window_scale = ProjectSettings.get("display/window/stretch/scale") - 1
+		
+		set_window_size(window_scale, ratio)
 
 func on_fps_toggled(value) -> void:
 	ProjectSettings.set_setting("game/ui/fps_counter", value)


### PR DESCRIPTION
There is still one problem: When set to 5:4 on a 16:9 screen, and set to fullscreen, the fullscreen view stretches instead of being padded with black bars.